### PR TITLE
Potential fix for code scanning alert no. 7: Unsafe expansion of self-closing HTML tag

### DIFF
--- a/static/admin/js/vendor/jquery/jquery.js
+++ b/static/admin/js/vendor/jquery/jquery.js
@@ -5976,7 +5976,8 @@ function remove( elem, selector, keepData ) {
 
 jQuery.extend( {
 	htmlPrefilter: function( html ) {
-		return html.replace( rxhtmlTag, "<$1></$2>" );
+		// Removed unsafe expansion of self-closing HTML tags.
+		return html;
 	},
 
 	clone: function( elem, dataAndEvents, deepDataAndEvents ) {


### PR DESCRIPTION
Potential fix for [https://github.com/nathandeflavis/final-cloud-app-with-database/security/code-scanning/7](https://github.com/nathandeflavis/final-cloud-app-with-database/security/code-scanning/7)

To fix the problem, we should avoid using a regular expression to expand self-closing HTML tags, as this can lead to unsafe transformations. The best way to handle this is to use a well-tested HTML parser to safely manipulate HTML strings, or to avoid expanding self-closing tags altogether. Since we cannot introduce large dependencies or change the overall functionality of jQuery, the safest minimal fix is to remove the expansion of self-closing tags from the `htmlPrefilter` function. Instead, we can simply return the input HTML unchanged, or, if necessary, use a safer approach that does not rely on regular expressions. This change should be made in the `htmlPrefilter` function in static/admin/js/vendor/jquery/jquery.js, specifically on line 5979.

No new imports or methods are needed; we simply need to change the implementation of `htmlPrefilter`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
